### PR TITLE
Add db foreign key migration

### DIFF
--- a/database/migrations/2020_10_27_030741_create_foreign_keys_for_role_user_table.php
+++ b/database/migrations/2020_10_27_030741_create_foreign_keys_for_role_user_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateForeignKeysForRoleUserTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('employees', function(Blueprint $table){
+            $table->dropForeign('employees_company_id_foreign');
+        });
+    }
+}


### PR DESCRIPTION
This PR adds a database foreign key migration. 
A foreign key will be added to the employees table, with the foreign key inserted onto the companies table.