### PR TITLE
Fixed HTML layout on company index page

### DIFF
--- a/resources/views/company/index.blade.php
+++ b/resources/views/company/index.blade.php
@@ -3,11 +3,13 @@
 @section('content')
 
 <div class="container">
-    <div style="float:left">
-        <h1>Company List</h1>
-    </div>
-    <div style="float:right">
-        <a href="{{ url('/company/create') }}" type="button" class="btn btn-success">Add Company</a>
+    <div class="row">
+        <div class="col">
+            <h1>Company List</h1>
+        </div>
+        <div class="col">
+            <a href="{{ url('/company/create') }}" type="button" class="btn btn-success float-right">Add Company</a>
+        </div>
     </div>
     @if(count($companies) > 0)
         <table class="table table-dark">


### PR DESCRIPTION
The HTML/CSS layout for the company index page doesn't behave appropriately when no values are present on the table. 
This fix resolves the issue by dropping the `float:left` style from the div and let Bootstrap's float-right style automatically adjust the view.