### PR TITLE
Fix routing issue for welcome and homepage

### DIFF
--- a/tipone_proj/app/Http/Controllers/HomeController.php
+++ b/tipone_proj/app/Http/Controllers/HomeController.php
@@ -38,4 +38,14 @@ class HomeController extends Controller
     {
         return view('home');
     }
+
+    /**
+     * Show the application welcome page.
+     *
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function welcome()
+    {
+        return view('welcome');
+    }
 }

--- a/tipone_proj/routes/api.php
+++ b/tipone_proj/routes/api.php
@@ -25,6 +25,10 @@ use Illuminate\Http\Request;
  *
  */
 
-Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user();
-});
+ /**
+  * Auto-generated route  by initial laravel installation.
+  * Comment out this part to prevent conflict with route:cache command
+  */
+// Route::middleware('auth:api')->get('/user', function (Request $request) {
+//     return $request->user();
+// });

--- a/tipone_proj/routes/web.php
+++ b/tipone_proj/routes/web.php
@@ -21,9 +21,10 @@
  *
  */
 
-Route::get('/', function () {
-    return view('welcome');
-});
+/**
+ * This line enables redirection from the root index to the welcome page.
+ */
+Route::get('/', 'HomeController@welcome')->name('welcome');
 
 /**
  *


### PR DESCRIPTION
The default routes created by Laravel during its initialization is unable to be processed by the command `php artisan route:cache`. The issue has been reported to the official Laravel repository since 2017. Link [here ](https://github.com/laravel/framework/issues/22034) for reference.

This PR issues a fix that replaces the offending code with a Route::get command that points to the HomeController controller function and properly handles the page redirection.